### PR TITLE
Fix item view being scrolled when tapping a comment

### DIFF
--- a/Hax/Models/Comment.swift
+++ b/Hax/Models/Comment.swift
@@ -5,7 +5,7 @@
 //  Created by Luis Fariña on 19/5/22.
 //
 
-struct Comment {
+struct Comment: Hashable {
 
     /// The item corresponding to the comment.
     let item: Item

--- a/Hax/Views/ItemView.swift
+++ b/Hax/Views/ItemView.swift
@@ -47,7 +47,7 @@ struct ItemView: View {
                             }
                         )
                     )
-                        .id(comment.id)
+                        .id(comment)
                         .onAppear {
                             if comment.id == viewModel.comments.last?.id {
                                 viewModel.fetchMoreComments()


### PR DESCRIPTION
Make `Comment` conform to `Hashable` and bind each comment row view's identity to its corresponding comment, so that the identity of the view is reset when any property of the comment changes.