### PR TITLE
Fix simplified URL being incorrect in some cases

### DIFF
--- a/Hax/Extensions/URLExtension.swift
+++ b/Hax/Extensions/URLExtension.swift
@@ -22,11 +22,6 @@ extension URL {
             return absoluteString
         }
 
-        let domainNameAndTLD = stringBeforeFirstSlash
-            .split(separator: ".")
-            .suffix(2)
-            .joined(separator: ".")
-
-        return domainNameAndTLD
+        return String(stringBeforeFirstSlash.trimmingPrefix("www."))
     }
 }

--- a/HaxTests/Tests/Extensions/URLExtensionTests.swift
+++ b/HaxTests/Tests/Extensions/URLExtensionTests.swift
@@ -55,4 +55,37 @@ final class URLExtensionTests: XCTestCase {
         // Then
         XCTAssertEqual(simpleString, "luisfl.me")
     }
+
+    func testSimpleString_givenIPAddress() throws {
+        // Given
+        let sut = try XCTUnwrap(URL(string: "https://1.1.1.1"))
+
+        // When
+        let simpleString = sut.simpleString()
+
+        // Then
+        XCTAssertEqual(simpleString, "1.1.1.1")
+    }
+
+    func testSimpleString_givenSLD() throws {
+        // Given
+        let sut = try XCTUnwrap(URL(string: "https://luisfl.co.jp"))
+
+        // When
+        let simpleString = sut.simpleString()
+
+        // Then
+        XCTAssertEqual(simpleString, "luisfl.co.jp")
+    }
+
+    func testSimpleString_givenWWW() throws {
+        // Given
+        let sut = try XCTUnwrap(URL(string: "https://www.luisfl.me"))
+
+        // When
+        let simpleString = sut.simpleString()
+
+        // Then
+        XCTAssertEqual(simpleString, "luisfl.me")
+    }
 }


### PR DESCRIPTION
Modify `URL.simpleString` to return the entire host and also trim the `www.` prefix if needed.