### PR TITLE
Use NavigationStack

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -21,7 +21,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: macos-latest
+    runs-on: macos-13
 
     steps:
       - name: Checkout

--- a/Hax.xcodeproj/project.pbxproj
+++ b/Hax.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		A092AD652954B8AC00B76D68 /* CommentRowViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A092AD642954B8AC00B76D68 /* CommentRowViewModelTests.swift */; };
 		A092AD672954BE9400B76D68 /* ItemRowViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A092AD662954BE9400B76D68 /* ItemRowViewModelTests.swift */; };
 		A0A2881829521A0500CF1484 /* FeedViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0A2881729521A0500CF1484 /* FeedViewModelTests.swift */; };
+		A0ACA52E2B935D9E00CFD2A8 /* MainViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0ACA52D2B935D9E00CFD2A8 /* MainViewModelTests.swift */; };
 		A0F3C6C32954A2E3008A7D2B /* XCTestCaseExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F3C6C22954A2E3008A7D2B /* XCTestCaseExtension.swift */; };
 		A0F3C6C52954A735008A7D2B /* ItemViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F3C6C42954A735008A7D2B /* ItemViewModelTests.swift */; };
 		A0F4DAFE28D4EA25006CD8E7 /* ViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F4DAF928D4EA25006CD8E7 /* ViewExtension.swift */; };
@@ -60,6 +61,8 @@
 		A0F4DB2C28D4EA3F006CD8E7 /* FeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F4DB1728D4EA3F006CD8E7 /* FeedView.swift */; };
 		A0F4DB2D28D4EA3F006CD8E7 /* MenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F4DB1828D4EA3F006CD8E7 /* MenuView.swift */; };
 		A0F4DB2E28D4EA3F006CD8E7 /* HackerNewsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F4DB1A28D4EA3F006CD8E7 /* HackerNewsService.swift */; };
+		A0F92DB92B934EA100FE61B8 /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F92DB82B934EA100FE61B8 /* MainView.swift */; };
+		A0F92DBB2B934ED200FE61B8 /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F92DBA2B934ED200FE61B8 /* MainViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -112,6 +115,7 @@
 		A092AD642954B8AC00B76D68 /* CommentRowViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentRowViewModelTests.swift; sourceTree = "<group>"; };
 		A092AD662954BE9400B76D68 /* ItemRowViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemRowViewModelTests.swift; sourceTree = "<group>"; };
 		A0A2881729521A0500CF1484 /* FeedViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedViewModelTests.swift; sourceTree = "<group>"; };
+		A0ACA52D2B935D9E00CFD2A8 /* MainViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModelTests.swift; sourceTree = "<group>"; };
 		A0F3C6C22954A2E3008A7D2B /* XCTestCaseExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestCaseExtension.swift; sourceTree = "<group>"; };
 		A0F3C6C42954A735008A7D2B /* ItemViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemViewModelTests.swift; sourceTree = "<group>"; };
 		A0F4DAF928D4EA25006CD8E7 /* ViewExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewExtension.swift; sourceTree = "<group>"; };
@@ -137,6 +141,8 @@
 		A0F4DB1728D4EA3F006CD8E7 /* FeedView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeedView.swift; sourceTree = "<group>"; };
 		A0F4DB1828D4EA3F006CD8E7 /* MenuView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuView.swift; sourceTree = "<group>"; };
 		A0F4DB1A28D4EA3F006CD8E7 /* HackerNewsService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HackerNewsService.swift; sourceTree = "<group>"; };
+		A0F92DB82B934EA100FE61B8 /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
+		A0F92DBA2B934ED200FE61B8 /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -192,6 +198,7 @@
 				A0A2881729521A0500CF1484 /* FeedViewModelTests.swift */,
 				A092AD662954BE9400B76D68 /* ItemRowViewModelTests.swift */,
 				A0F3C6C42954A735008A7D2B /* ItemViewModelTests.swift */,
+				A0ACA52D2B935D9E00CFD2A8 /* MainViewModelTests.swift */,
 				A01F70EE2952064800395B2A /* MenuViewModelTests.swift */,
 				A01F70F429520FD600395B2A /* SettingsViewModelTests.swift */,
 			);
@@ -346,6 +353,7 @@
 				A0F4DB0E28D4EA3F006CD8E7 /* FeedViewModel.swift */,
 				A0F4DB0A28D4EA3F006CD8E7 /* ItemRowViewModel.swift */,
 				A0F4DB0928D4EA3F006CD8E7 /* ItemViewModel.swift */,
+				A0F92DBA2B934ED200FE61B8 /* MainViewModel.swift */,
 				A0F4DB0C28D4EA3F006CD8E7 /* MenuViewModel.swift */,
 				A0F4DB0B28D4EA3F006CD8E7 /* SettingsViewModel.swift */,
 			);
@@ -360,6 +368,7 @@
 				A0F4DB1728D4EA3F006CD8E7 /* FeedView.swift */,
 				A0F4DB1428D4EA3F006CD8E7 /* ItemRowView.swift */,
 				A0F4DB1128D4EA3F006CD8E7 /* ItemView.swift */,
+				A0F92DB82B934EA100FE61B8 /* MainView.swift */,
 				A0F4DB1828D4EA3F006CD8E7 /* MenuView.swift */,
 				A0F4DB1028D4EA3F006CD8E7 /* SafariView.swift */,
 				A0F4DB1228D4EA3F006CD8E7 /* SettingsView.swift */,
@@ -546,6 +555,7 @@
 				A0F4DB1E28D4EA3F006CD8E7 /* Feed.swift in Sources */,
 				A0F4DB2E28D4EA3F006CD8E7 /* HackerNewsService.swift in Sources */,
 				A0F4DB2628D4EA3F006CD8E7 /* ItemView.swift in Sources */,
+				A0F92DBB2B934ED200FE61B8 /* MainViewModel.swift in Sources */,
 				A0F4DB2528D4EA3F006CD8E7 /* SafariView.swift in Sources */,
 				A01F70F129520AAF00395B2A /* AppVersionService.swift in Sources */,
 				A0F4DB1F28D4EA3F006CD8E7 /* ItemViewModel.swift in Sources */,
@@ -566,6 +576,7 @@
 				A0F4DB1D28D4EA3F006CD8E7 /* IdentifiableURL.swift in Sources */,
 				A0F4DB2228D4EA3F006CD8E7 /* MenuViewModel.swift in Sources */,
 				A0F4DB2028D4EA3F006CD8E7 /* ItemRowViewModel.swift in Sources */,
+				A0F92DB92B934EA100FE61B8 /* MainView.swift in Sources */,
 				A0F4DB2828D4EA3F006CD8E7 /* CommentRowView.swift in Sources */,
 				A0F4DB2128D4EA3F006CD8E7 /* SettingsViewModel.swift in Sources */,
 				A0F4DB2728D4EA3F006CD8E7 /* SettingsView.swift in Sources */,
@@ -579,6 +590,7 @@
 				A01F70F7295213B800395B2A /* AppVersionServiceMock.swift in Sources */,
 				A067889329530F9A00AA7BE0 /* ArrayExtensionTests.swift in Sources */,
 				A0A2881829521A0500CF1484 /* FeedViewModelTests.swift in Sources */,
+				A0ACA52E2B935D9E00CFD2A8 /* MainViewModelTests.swift in Sources */,
 				A01F70EA2952054200395B2A /* UserDefaultsMock.swift in Sources */,
 				A0678891295309A400AA7BE0 /* DateExtensionTests.swift in Sources */,
 				A092AD652954B8AC00B76D68 /* CommentRowViewModelTests.swift in Sources */,
@@ -756,7 +768,7 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 12.3;
@@ -796,7 +808,7 @@
 				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 12.3;
@@ -822,7 +834,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = B2NJF5A6ZC;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
 				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.luisfl.HaxTests;
@@ -847,7 +859,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = B2NJF5A6ZC;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
 				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.luisfl.HaxTests;
@@ -871,7 +883,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = B2NJF5A6ZC;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
 				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.luisfl.HaxUITests;
@@ -895,7 +907,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = B2NJF5A6ZC;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.2;
 				MACOSX_DEPLOYMENT_TARGET = 12.3;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.luisfl.HaxUITests;

--- a/Hax/HaxApp.swift
+++ b/Hax/HaxApp.swift
@@ -10,9 +10,11 @@ import SwiftUI
 @main
 struct HaxApp: App {
 
+    // MARK: Body
+
     var body: some Scene {
         WindowGroup {
-            MenuView(model: MenuViewModel())
+            MainView(model: MainViewModel())
         }
     }
 }

--- a/Hax/Models/Feed.swift
+++ b/Hax/Models/Feed.swift
@@ -78,3 +78,12 @@ enum Feed: String, CaseIterable {
         return title
     }
 }
+
+// MARK: - Identifiable
+
+extension Feed: Identifiable {
+
+    var id: Self {
+        self
+    }
+}

--- a/Hax/View Models/FeedViewModel.swift
+++ b/Hax/View Models/FeedViewModel.swift
@@ -25,9 +25,6 @@ protocol FeedViewModelProtocol: ObservableObject {
     /// The array of items to display in the list.
     var items: [Item] { get }
 
-    /// The selected item.
-    var selectedItem: Item? { get set }
-
     /// The URL to navigate to.
     var url: IdentifiableURL? { get set }
 
@@ -38,12 +35,6 @@ protocol FeedViewModelProtocol: ObservableObject {
 
     /// Called when an item appears.
     func onItemAppear(item: Item)
-
-    /// Called when the button of an item is triggered.
-    func onItemButtonTrigger(item: Item)
-
-    /// Called when the number of comments of an item is tapped.
-    func onNumberOfCommentsTap(item: Item)
 }
 
 class FeedViewModel: FeedViewModelProtocol {
@@ -54,7 +45,6 @@ class FeedViewModel: FeedViewModelProtocol {
     @Published var isLoading = true
     @Published var error: Error?
     @Published var items: [Item] = []
-    @Published var selectedItem: Item?
     @Published var url: IdentifiableURL?
 
     /// The service to use for fetching Hacker News data.
@@ -97,18 +87,6 @@ class FeedViewModel: FeedViewModelProtocol {
 
         page += 1
         fetchItems(resetCache: false)
-    }
-
-    func onItemButtonTrigger(item: Item) {
-        if let url = item.url {
-            self.url = IdentifiableURL(url)
-        } else {
-            onNumberOfCommentsTap(item: item)
-        }
-    }
-
-    func onNumberOfCommentsTap(item: Item) {
-        selectedItem = item
     }
 }
 

--- a/Hax/View Models/MainViewModel.swift
+++ b/Hax/View Models/MainViewModel.swift
@@ -1,0 +1,34 @@
+//
+//  MainViewModel.swift
+//  Hax
+//
+//  Created by Luis Fariña on 2/3/24.
+//
+
+import Foundation
+
+@MainActor
+protocol MainViewModelProtocol: ObservableObject {
+
+    // MARK: Properties
+
+    /// The selected feed.
+    var selectedFeed: Feed? { get set }
+
+    /// The selected item.
+    var selectedItem: Item? { get set }
+}
+
+final class MainViewModel: MainViewModelProtocol {
+
+    // MARK: Properties
+
+    @Published var selectedFeed: Feed?
+    @Published var selectedItem: Item?
+
+    // MARK: Initialization
+
+    init(defaultFeedService: some DefaultFeedServiceProtocol = DefaultFeedService()) {
+        selectedFeed = defaultFeedService.defaultFeed()
+    }
+}

--- a/Hax/View Models/MenuViewModel.swift
+++ b/Hax/View Models/MenuViewModel.swift
@@ -14,9 +14,6 @@ protocol MenuViewModelProtocol: ObservableObject {
 
     /// The array of feeds to display in the list.
     var feeds: [Feed] { get }
-
-    /// The selected feed.
-    var selectedFeed: Feed? { get set }
 }
 
 final class MenuViewModel: MenuViewModelProtocol {
@@ -24,11 +21,4 @@ final class MenuViewModel: MenuViewModelProtocol {
     // MARK: Properties
 
     let feeds = Feed.allCases
-    @Published var selectedFeed: Feed?
-
-    // MARK: Initialization
-
-    init(defaultFeedService: some DefaultFeedServiceProtocol = DefaultFeedService()) {
-        selectedFeed = defaultFeedService.defaultFeed()
-    }
 }

--- a/Hax/Views/FeedView.swift
+++ b/Hax/Views/FeedView.swift
@@ -12,6 +12,7 @@ struct FeedView<Model: FeedViewModelProtocol>: View {
     // MARK: Properties
 
     @StateObject var model: Model
+    @Binding private(set) var selectedItem: Item?
 
     // MARK: Body
 
@@ -21,33 +22,22 @@ struct FeedView<Model: FeedViewModelProtocol>: View {
                 ActivityIndicatorView()
             } else {
                 List(enumeratedItems, id: \.1) { index, item in
-                    ZStack {
-                        Button {
-                            model.onItemButtonTrigger(item: item)
-                        } label: {
-                            ItemRowView(
-                                model: ItemRowViewModel(
-                                    in: .feed,
-                                    index: index + 1,
-                                    item: item,
-                                    onNumberOfCommentsTap: {
-                                        model.onNumberOfCommentsTap(
-                                            item: item
-                                        )
-                                    }
-                                )
-                            )
+                    Button {
+                        if let url = item.url {
+                            model.url = IdentifiableURL(url)
+                        } else {
+                            selectedItem = item
                         }
-                        NavigationLink(
-                            tag: item,
-                            selection: $model.selectedItem
-                        ) {
-                            ItemView(
-                                model: ItemViewModel(item: item)
-                            )
-                        } label: {
-                            EmptyView()
-                        }.opacity(0).disabled(true)
+                    } label: {
+                        ItemRowView(
+                            model: ItemRowViewModel(
+                                in: .feed,
+                                index: index + 1,
+                                item: item
+                            ) {
+                                selectedItem = item
+                            }
+                        )
                     }
                     .contextMenu {
                         if let url = item.url {
@@ -102,8 +92,11 @@ struct FeedView_Previews: PreviewProvider {
     // MARK: Previews
 
     static var previews: some View {
-        NavigationView {
-            FeedView(model: Model(feed: .top))
+        NavigationStack {
+            FeedView(
+                model: Model(feed: .top),
+                selectedItem: .constant(nil)
+            )
         }
     }
 }

--- a/Hax/Views/ItemView.swift
+++ b/Hax/Views/ItemView.swift
@@ -96,7 +96,7 @@ struct ItemView_Previews: PreviewProvider {
     // MARK: Previews
 
     static var previews: some View {
-        NavigationView {
+        NavigationStack {
             ItemView(model: Model(item: .example))
         }
     }

--- a/Hax/Views/MainView.swift
+++ b/Hax/Views/MainView.swift
@@ -1,0 +1,41 @@
+//
+//  MainView.swift
+//  Hax
+//
+//  Created by Luis Fariña on 2/3/24.
+//
+
+import SwiftUI
+
+struct MainView<Model: MainViewModelProtocol>: View {
+
+    // MARK: Properties
+
+    @StateObject var model: Model
+
+    // MARK: Body
+
+    var body: some View {
+        NavigationStack {
+            MenuView(
+                model: MenuViewModel(),
+                selectedFeed: $model.selectedFeed
+            )
+            .navigationDestination(item: $model.selectedFeed) { feed in
+                FeedView(
+                    model: FeedViewModel(feed: feed),
+                    selectedItem: $model.selectedItem
+                )
+                .navigationDestination(item: $model.selectedItem) { item in
+                    ItemView(model: ItemViewModel(item: item))
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview {
+    MainView(model: MainViewModel())
+}

--- a/Hax/Views/MenuView.swift
+++ b/Hax/Views/MenuView.swift
@@ -12,48 +12,42 @@ struct MenuView<Model: MenuViewModelProtocol>: View {
     // MARK: Properties
 
     @StateObject var model: Model
+    @Binding private(set) var selectedFeed: Feed?
 
     // MARK: Body
 
     var body: some View {
-        NavigationView {
-            List {
-                Section {
-                    ForEach(model.feeds, id: \.self) { feed in
-                        NavigationLink(
-                            tag: feed,
-                            selection: $model.selectedFeed
-                        ) {
-                            FeedView(
-                                model: FeedViewModel(feed: feed)
-                            )
-                        } label: {
-                            Label(
-                                feed.title,
-                                systemImage: feed.systemImage
-                            )
-                        }
-                    }
-                }
-                Section {
-                    NavigationLink {
-                        SettingsView(model: SettingsViewModel())
-                    } label: {
-                        Label("Settings", systemImage: "gearshape")
+        List(selection: $selectedFeed) {
+            Section {
+                ForEach(model.feeds) { feed in
+                    NavigationLink(value: feed) {
+                        Label(
+                            feed.title,
+                            systemImage: feed.systemImage
+                        )
                     }
                 }
             }
-            .listStyle(.insetGrouped)
-            .navigationTitle("Feeds")
+            Section {
+                NavigationLink {
+                    SettingsView(model: SettingsViewModel())
+                } label: {
+                    Label("Settings", systemImage: "gearshape")
+                }
+            }
         }
+        .listStyle(.insetGrouped)
+        .navigationTitle("Feeds")
     }
 }
 
 // MARK: - Previews
 
-struct MenuView_Previews: PreviewProvider {
-
-    static var previews: some View {
-        MenuView(model: MenuViewModel())
+#Preview {
+    NavigationStack {
+        MenuView(
+            model: MenuViewModel(),
+            selectedFeed: .constant(nil)
+        )
     }
 }

--- a/Hax/Views/SettingsView.swift
+++ b/Hax/Views/SettingsView.swift
@@ -54,7 +54,7 @@ struct SettingsView<Model: SettingsViewModelProtocol>: View {
 struct SettingsView_Previews: PreviewProvider {
 
     static var previews: some View {
-        NavigationView {
+        NavigationStack {
             SettingsView(model: SettingsViewModel())
         }
     }

--- a/HaxTests/Tests/View Models/FeedViewModelTests.swift
+++ b/HaxTests/Tests/View Models/FeedViewModelTests.swift
@@ -46,7 +46,6 @@ final class FeedViewModelTests: XCTestCase {
         XCTAssert(sut.isLoading)
         XCTAssertNil(sut.error)
         XCTAssertEqual(sut.items, [])
-        XCTAssertNil(sut.selectedItem)
         XCTAssertNil(sut.url)
     }
 
@@ -136,40 +135,6 @@ final class FeedViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(hackerNewsServiceMock.itemsCallCount, 0)
-    }
-
-    func testOnItemButtonTrigger_givenItemWithURL() throws {
-        // Given
-        let url = try XCTUnwrap(URL(string: "luisfl.me"))
-        let item = Item(url: url)
-
-        // When
-        sut.onItemButtonTrigger(item: item)
-
-        // Then
-        XCTAssertNil(sut.selectedItem)
-        XCTAssertEqual(sut.url?.url, url)
-    }
-
-    func testOnItemButtonTrigger_givenItemWithoutURL() {
-        // Given
-        let item = Item()
-
-        // When
-        sut.onItemButtonTrigger(item: item)
-
-        // Then
-        XCTAssertEqual(sut.selectedItem, item)
-        XCTAssertNil(sut.url)
-    }
-
-    func testOnNumberOfCommentsTap() {
-        // When
-        sut.onNumberOfCommentsTap(item: .example)
-
-        // Then
-        XCTAssertEqual(sut.selectedItem, .example)
-        XCTAssertNil(sut.url)
     }
 }
 

--- a/HaxTests/Tests/View Models/MainViewModelTests.swift
+++ b/HaxTests/Tests/View Models/MainViewModelTests.swift
@@ -1,0 +1,45 @@
+//
+//  MainViewModelTests.swift
+//  HaxTests
+//
+//  Created by Luis Fariña on 2/3/24.
+//
+
+import XCTest
+@testable import Hax
+
+@MainActor
+final class MainViewModelTests: XCTestCase {
+
+    // MARK: Properties
+
+    private var sut: MainViewModel!
+    private var defaultFeedServiceMock: DefaultFeedServiceMock!
+
+    // MARK: Set up and tear down
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        defaultFeedServiceMock = DefaultFeedServiceMock()
+        defaultFeedServiceMock.defaultFeedStub = .best
+        sut = MainViewModel(defaultFeedService: defaultFeedServiceMock)
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+        defaultFeedServiceMock = nil
+
+        try super.tearDownWithError()
+    }
+
+    // MARK: Tests
+
+    func testInit() {
+        XCTAssertEqual(sut.selectedFeed, .best)
+        XCTAssertEqual(
+            defaultFeedServiceMock.defaultFeedCallCount,
+            1
+        )
+    }
+}

--- a/HaxTests/Tests/View Models/MenuViewModelTests.swift
+++ b/HaxTests/Tests/View Models/MenuViewModelTests.swift
@@ -14,16 +14,13 @@ final class MenuViewModelTests: XCTestCase {
     // MARK: Properties
 
     private var sut: MenuViewModel!
-    private var defaultFeedServiceMock: DefaultFeedServiceMock!
 
     // MARK: Set up and tear down
 
     override func setUpWithError() throws {
         try super.setUpWithError()
 
-        defaultFeedServiceMock = DefaultFeedServiceMock()
-        defaultFeedServiceMock.defaultFeedStub = .best
-        sut = MenuViewModel(defaultFeedService: defaultFeedServiceMock)
+        sut = MenuViewModel()
     }
 
     override func tearDownWithError() throws {
@@ -36,10 +33,5 @@ final class MenuViewModelTests: XCTestCase {
 
     func testInit() {
         XCTAssertEqual(sut.feeds, Feed.allCases)
-        XCTAssertEqual(sut.selectedFeed, .best)
-        XCTAssertEqual(
-            defaultFeedServiceMock.defaultFeedCallCount,
-            1
-        )
     }
 }


### PR DESCRIPTION
- Use `NavigationStack` instead of `NavigationView`, which is deprecated
- Create `MainView` and make it the initial view of the app, decoupling the navigation logic from `MenuView` and `FeedView`
- Use the new `Preview` macro when applicable
- Modify the GitHub workflow so that it's run on macOS 13 and consequently uses Xcode 15