### PR TITLE
Fix crash when tapping email address in comment

### DIFF
--- a/Hax/View Models/CommentRowViewModel.swift
+++ b/Hax/View Models/CommentRowViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by Luis Fariña on 20/6/22.
 //
 
-import Foundation
+import SwiftUI
 
 protocol CommentRowViewModelProtocol {
 
@@ -15,7 +15,7 @@ protocol CommentRowViewModelProtocol {
     var comment: Comment { get }
 
     /// The action to be carried out when tapping a link in the body of the comment.
-    var onLinkTap: ((URL) -> Void)? { get }
+    var onLinkTap: ((URL) -> OpenURLAction.Result)? { get }
 
     /// Whether the author of the comment should be highlighted.
     var shouldHighlightAuthor: Bool { get }
@@ -26,7 +26,7 @@ struct CommentRowViewModel: CommentRowViewModelProtocol {
     // MARK: Properties
 
     let comment: Comment
-    let onLinkTap: ((URL) -> Void)?
+    let onLinkTap: ((URL) -> OpenURLAction.Result)?
     let shouldHighlightAuthor: Bool
 
     // MARK: Initialization
@@ -34,7 +34,7 @@ struct CommentRowViewModel: CommentRowViewModelProtocol {
     init(
         comment: Comment,
         item: Item,
-        onLinkTap: ((URL) -> Void)? = nil
+        onLinkTap: ((URL) -> OpenURLAction.Result)? = nil
     ) {
         self.comment = comment
         self.onLinkTap = onLinkTap

--- a/Hax/View Models/ItemRowViewModel.swift
+++ b/Hax/View Models/ItemRowViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by Luis Fariña on 27/5/22.
 //
 
-import Foundation
+import SwiftUI
 
 enum ItemRowViewModelView: CaseIterable {
 
@@ -46,7 +46,7 @@ protocol ItemRowViewModelProtocol {
     var onNumberOfCommentsTap: (() -> Void)? { get }
 
     /// The action to be carried out when tapping a link in the body of the item.
-    var onLinkTap: ((URL) -> Void)? { get }
+    var onLinkTap: ((URL) -> OpenURLAction.Result)? { get }
 
     /// Whether the index of the item should be displayed.
     var shouldDisplayIndex: Bool { get }
@@ -72,7 +72,7 @@ struct ItemRowViewModel: ItemRowViewModelProtocol {
     let index: Int
     let item: Item
     let onNumberOfCommentsTap: (() -> Void)?
-    let onLinkTap: ((URL) -> Void)?
+    let onLinkTap: ((URL) -> OpenURLAction.Result)?
 
     var shouldDisplayIndex: Bool {
         view == .feed
@@ -101,7 +101,7 @@ struct ItemRowViewModel: ItemRowViewModelProtocol {
         index: Int = 1,
         item: Item,
         onNumberOfCommentsTap: (() -> Void)? = nil,
-        onLinkTap: ((URL) -> Void)? = nil
+        onLinkTap: ((URL) -> OpenURLAction.Result)? = nil
     ) {
         self.view = view
         self.index = index

--- a/Hax/View Models/ItemViewModel.swift
+++ b/Hax/View Models/ItemViewModel.swift
@@ -6,7 +6,7 @@
 //
 
 import Combine
-import UIKit
+import SwiftUI
 
 @MainActor
 protocol ItemViewModelProtocol: ObservableObject {
@@ -46,7 +46,7 @@ protocol ItemViewModelProtocol: ObservableObject {
     func onCommentTap(comment: Comment)
 
     /// Called when a link in a comment is tapped.
-    func onCommentLinkTap(url: URL)
+    func onCommentLinkTap(url: URL) -> OpenURLAction.Result
 }
 
 class ItemViewModel: ItemViewModelProtocol {
@@ -159,11 +159,15 @@ class ItemViewModel: ItemViewModelProtocol {
         }
     }
 
-    func onCommentLinkTap(url: URL) {
+    func onCommentLinkTap(url: URL) -> OpenURLAction.Result {
         if let itemID = regexService.itemID(url: url) {
             secondaryItem = Item(id: itemID)
-        } else {
+            return .handled
+        } else if url.scheme?.hasPrefix("http") == true {
             self.url = IdentifiableURL(url)
+            return .handled
+        } else {
+            return .systemAction
         }
     }
 }

--- a/Hax/Views/CommentRowView.swift
+++ b/Hax/Views/CommentRowView.swift
@@ -43,8 +43,7 @@ struct CommentRowView<Model: CommentRowViewModelProtocol>: View {
                         .environment(
                             \.openURL,
                              OpenURLAction { url in
-                                 model.onLinkTap?(url)
-                                 return .handled
+                                 model.onLinkTap?(url) ?? .systemAction
                              }
                         )
                 }
@@ -100,14 +99,14 @@ private struct PreviewCommentRowViewModel: CommentRowViewModelProtocol {
     // MARK: Properties
 
     let comment: Comment
-    let onLinkTap: ((URL) -> Void)?
+    let onLinkTap: ((URL) -> OpenURLAction.Result)?
     let shouldHighlightAuthor: Bool
 
     // MARK: Initialization
 
     init(
         comment: Comment = .example,
-        onLinkTap: ((URL) -> Void)? = nil,
+        onLinkTap: ((URL) -> OpenURLAction.Result)? = nil,
         shouldHighlightAuthor: Bool = false
     ) {
         self.comment = comment

--- a/Hax/Views/ItemRowView.swift
+++ b/Hax/Views/ItemRowView.swift
@@ -39,8 +39,7 @@ struct ItemRowView<Model: ItemRowViewModelProtocol>: View {
                             .environment(
                                 \.openURL,
                                  OpenURLAction { url in
-                                     model.onLinkTap?(url)
-                                     return .handled
+                                     model.onLinkTap?(url) ?? .systemAction
                                  }
                             )
                             .font(.subheadline)

--- a/HaxTests/Tests/View Models/CommentRowViewModelTests.swift
+++ b/HaxTests/Tests/View Models/CommentRowViewModelTests.swift
@@ -23,8 +23,10 @@ final class CommentRowViewModelTests: XCTestCase {
             item: Item(author: "2")
         ) { _ in
             onLinkTapCallCount += 1
+
+            return .handled
         }
-        sut.onLinkTap?(url)
+        _ = sut.onLinkTap?(url)
 
         // Then
         XCTAssertEqual(sut.comment, .example)

--- a/HaxTests/Tests/View Models/ItemRowViewModelTests.swift
+++ b/HaxTests/Tests/View Models/ItemRowViewModelTests.swift
@@ -56,10 +56,12 @@ final class ItemRowViewModelTests: XCTestCase {
             },
             onLinkTap: { _ in
                 onLinkTapCallCount += 1
+
+                return .handled
             }
         )
         sut.onNumberOfCommentsTap?()
-        sut.onLinkTap?(url)
+        _ = sut.onLinkTap?(url)
 
         // Then
         XCTAssertEqual(sut.view, .feed)

--- a/HaxTests/Tests/View Models/ItemViewModelTests.swift
+++ b/HaxTests/Tests/View Models/ItemViewModelTests.swift
@@ -222,12 +222,25 @@ final class ItemViewModelTests: XCTestCase {
         )
     }
 
-    func testOnCommentLinkTap_givenLinkDoesNotContainHackerNewsItemIdentifier() throws {
+    func testOnCommentLinkTap_givenLinkDoesNotContainHackerNewsItemIdentifierAndSchemeDoesNotStartWithHTTP() throws {
+        // Given
+        let url = try XCTUnwrap(URL(string: "example@example.com"))
+
+        // When
+        _ = sut.onCommentLinkTap(url: url)
+
+        // Then
+        XCTAssertNil(sut.secondaryItem)
+        XCTAssertNil(sut.url)
+        XCTAssertEqual(regexServiceMock.itemIDCallCount, 1)
+    }
+
+    func testOnCommentLinkTap_givenLinkDoesNotContainHackerNewsItemIdentifierAndSchemeStartsWithHTTP() throws {
         // Given
         let url = try XCTUnwrap(URL(string: "https://luisfl.me"))
 
         // When
-        sut.onCommentLinkTap(url: url)
+        _ = sut.onCommentLinkTap(url: url)
 
         // Then
         XCTAssertNil(sut.secondaryItem)
@@ -241,7 +254,7 @@ final class ItemViewModelTests: XCTestCase {
         let url = try XCTUnwrap(URL(string: "news.ycombinator.com/item?id=1"))
 
         // When
-        sut.onCommentLinkTap(url: url)
+        _ = sut.onCommentLinkTap(url: url)
 
         // Then
         XCTAssertEqual(sut.secondaryItem?.id, 1)


### PR DESCRIPTION
Only present a `SafariView` if the scheme of the tapped link is HTTP or HTTPS. Otherwise, let iOS handle the link.