### PR TITLE
Refresh item

### DIFF
--- a/Hax/Services/HackerNewsService.swift
+++ b/Hax/Services/HackerNewsService.swift
@@ -37,27 +37,6 @@ protocol HackerNewsServiceProtocol {
 
     // MARK: Methods
 
-    /// Returns a publisher that resolves to a specific page of comments in an item.
-    ///
-    /// - Parameters:
-    ///   - item: The item to be fetched
-    ///   - page: The page of comments to fetch
-    ///   - pageSize: The size of each page
-    func comments(
-        in item: Item,
-        page: Int,
-        pageSize: Int
-    ) -> AnyPublisher<[Comment], Error>
-
-    /// Returns a publisher that resolves to the item with the specified identifier and its
-    /// corresponding information.
-    ///
-    /// - Parameters:
-    ///   - id: The identifier of the item to be fetched
-    func item(
-        id: Int
-    ) -> AnyPublisher<Item, Error>
-
     /// Fetches a specific page of comments in an item.
     ///
     /// - Parameters:
@@ -112,29 +91,6 @@ final class HackerNewsService: HackerNewsServiceProtocol {
     }()
 
     // MARK: Methods
-
-    func comments(
-        in item: Item,
-        page: Int,
-        pageSize: Int = Constant.itemPageSize
-    ) -> AnyPublisher<[Comment], Error> {
-        let identifiersForPage = item.children
-            .dropFirst(pageSize * (page - 1))
-            .prefix(pageSize)
-
-        return comments(for: Array(identifiersForPage))
-    }
-
-    func item(
-        id: Int
-    ) -> AnyPublisher<Item, Error> {
-        guard let url = Endpoint.item(id).url else {
-            return Fail(error: HackerNewsServiceError.unknown)
-                .eraseToAnyPublisher()
-        }
-
-        return request(url: url)
-    }
 
     func comments(
         in item: Item,
@@ -204,6 +160,29 @@ private extension HackerNewsService {
     }
 
     // MARK: Methods
+
+    func comments(
+        in item: Item,
+        page: Int,
+        pageSize: Int = Constant.itemPageSize
+    ) -> AnyPublisher<[Comment], Error> {
+        let identifiersForPage = item.children
+            .dropFirst(pageSize * (page - 1))
+            .prefix(pageSize)
+
+        return comments(for: Array(identifiersForPage))
+    }
+
+    func item(
+        id: Int
+    ) -> AnyPublisher<Item, Error> {
+        guard let url = Endpoint.item(id).url else {
+            return Fail(error: HackerNewsServiceError.unknown)
+                .eraseToAnyPublisher()
+        }
+
+        return request(url: url)
+    }
 
     func items(
         in feed: Feed,

--- a/Hax/View Models/FeedViewModel.swift
+++ b/Hax/View Models/FeedViewModel.swift
@@ -140,8 +140,7 @@ private extension FeedViewModel {
         } catch {
             self.error = error
         }
-        if isLoading {
-            isLoading = false
-        }
+
+        isLoading = false
     }
 }

--- a/Hax/Views/ItemView.swift
+++ b/Hax/Views/ItemView.swift
@@ -68,6 +68,9 @@ struct ItemView<Model: ItemViewModelProtocol>: View {
         .onAppear {
             model.onViewAppear()
         }
+        .refreshable {
+            await model.onRefreshRequest()
+        }
         .safari(url: $model.url)
         .toolbar {
             if let url = model.item.url {

--- a/HaxTests/Mocks/HackerNewsServiceMock.swift
+++ b/HaxTests/Mocks/HackerNewsServiceMock.swift
@@ -25,22 +25,6 @@ final class HackerNewsServiceMock: HackerNewsServiceProtocol {
         in item: Item,
         page: Int,
         pageSize: Int
-    ) -> AnyPublisher<[Comment], Error> {
-        commentsCallCount += 1
-
-        return publisher(stub: commentsStub)
-    }
-
-    func item(id: Int) -> AnyPublisher<Item, Error> {
-        itemCallCount += 1
-
-        return publisher(stub: itemStub)
-    }
-
-    func comments(
-        in item: Item,
-        page: Int,
-        pageSize: Int
     ) async throws -> [Comment] {
         commentsCallCount += 1
 
@@ -70,17 +54,6 @@ final class HackerNewsServiceMock: HackerNewsServiceProtocol {
 private extension HackerNewsServiceMock {
 
     // MARK: Methods
-
-    func publisher<T>(stub: T?) -> AnyPublisher<T, Error> {
-        guard let stub else {
-            return Fail(error: HackerNewsServiceError.network)
-                .eraseToAnyPublisher()
-        }
-
-        return Just(stub)
-            .setFailureType(to: Error.self)
-            .eraseToAnyPublisher()
-    }
 
     func stubOrError<T>(_ stub: T?) throws -> T {
         guard let stub else {


### PR DESCRIPTION
Modify `ItemViewModel` to use the `async` versions of the `HackerNewsServiceProtocol` `item` and `comments` methods, and define the `onRefreshRequest` method, which is to be called by `ItemView` through `refreshable`.