### PR TITLE
Implement filters

### DIFF
--- a/Hax.xcodeproj/project.pbxproj
+++ b/Hax.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		A025292F2BC31A7B009FAAB2 /* ShareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A025292E2BC31A7B009FAAB2 /* ShareView.swift */; };
 		A02529312BC31C8B009FAAB2 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = A02529302BC31C8B009FAAB2 /* Constant.swift */; };
 		A02529322BC31CC7009FAAB2 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = A02529302BC31C8B009FAAB2 /* Constant.swift */; };
+		A0266F662BDAA715007ED222 /* StringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0266F652BDAA715007ED222 /* StringExtensionTests.swift */; };
 		A03FDF672AB74E5A00127AB6 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A03FDF662AB74E5A00127AB6 /* WidgetKit.framework */; };
 		A03FDF692AB74E5A00127AB6 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A03FDF682AB74E5A00127AB6 /* SwiftUI.framework */; };
 		A03FDF6C2AB74E5A00127AB6 /* HaxWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A03FDF6B2AB74E5A00127AB6 /* HaxWidgetBundle.swift */; };
@@ -29,6 +30,11 @@
 		A03FDF7F2AB7535100127AB6 /* HaxWidgetEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A03FDF7E2AB7535100127AB6 /* HaxWidgetEntry.swift */; };
 		A04316172BC9955E00C0CE7E /* popup.js in Resources */ = {isa = PBXBuildFile; fileRef = A04316162BC9955E00C0CE7E /* popup.js */; };
 		A04500932BBB239E006227CE /* FeedExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04500922BBB239E006227CE /* FeedExtension.swift */; };
+		A049CE242BCAB9410068BE9F /* FilterService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A049CE232BCAB9410068BE9F /* FilterService.swift */; };
+		A057C71B2BCED02A00B6FA11 /* FilterServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A057C71A2BCED02A00B6FA11 /* FilterServiceTests.swift */; };
+		A05938202BCA96910042802D /* FilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A059381F2BCA96910042802D /* FilterView.swift */; };
+		A05938222BCA97E10042802D /* KeywordFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A05938212BCA97E10042802D /* KeywordFilter.swift */; };
+		A05938262BCA9C210042802D /* UserFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A05938252BCA9C210042802D /* UserFilter.swift */; };
 		A064ABAD28D3ADA500572ADD /* HaxApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A064ABAC28D3ADA500572ADD /* HaxApp.swift */; };
 		A064ABB128D3ADA600572ADD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A064ABB028D3ADA600572ADD /* Assets.xcassets */; };
 		A064ABB528D3ADA600572ADD /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A064ABB428D3ADA600572ADD /* Preview Assets.xcassets */; };
@@ -74,6 +80,9 @@
 		A0D56A8C2BAB32F00095BDD6 /* RegexService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D56A8B2BAB32F00095BDD6 /* RegexService.swift */; };
 		A0D56A8E2BAB35220095BDD6 /* RegexServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D56A8D2BAB35220095BDD6 /* RegexServiceTests.swift */; };
 		A0DEE10D2AB6F7F5000918CB /* AnyPublisherExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0DEE10C2AB6F7F5000918CB /* AnyPublisherExtension.swift */; };
+		A0DF5DA02BD2E35A00BD93CD /* FilterService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A049CE232BCAB9410068BE9F /* FilterService.swift */; };
+		A0DF5DA12BD2E36500BD93CD /* KeywordFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A05938212BCA97E10042802D /* KeywordFilter.swift */; };
+		A0DF5DA22BD2E36900BD93CD /* UserFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A05938252BCA9C210042802D /* UserFilter.swift */; };
 		A0E318C52BB2D51B002BD063 /* RegexServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0E318C42BB2D51B002BD063 /* RegexServiceMock.swift */; };
 		A0F3C6C32954A2E3008A7D2B /* XCTestCaseExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F3C6C22954A2E3008A7D2B /* XCTestCaseExtension.swift */; };
 		A0F3C6C52954A735008A7D2B /* ItemViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F3C6C42954A735008A7D2B /* ItemViewModelTests.swift */; };
@@ -162,6 +171,7 @@
 		A01F70F6295213B800395B2A /* AppVersionServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionServiceMock.swift; sourceTree = "<group>"; };
 		A025292E2BC31A7B009FAAB2 /* ShareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareView.swift; sourceTree = "<group>"; };
 		A02529302BC31C8B009FAAB2 /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
+		A0266F652BDAA715007ED222 /* StringExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensionTests.swift; sourceTree = "<group>"; };
 		A03FDF642AB74E5A00127AB6 /* HaxWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = HaxWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		A03FDF662AB74E5A00127AB6 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		A03FDF682AB74E5A00127AB6 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
@@ -173,6 +183,11 @@
 		A03FDF7E2AB7535100127AB6 /* HaxWidgetEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HaxWidgetEntry.swift; sourceTree = "<group>"; };
 		A04316162BC9955E00C0CE7E /* popup.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = popup.js; sourceTree = "<group>"; };
 		A04500922BBB239E006227CE /* FeedExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedExtension.swift; sourceTree = "<group>"; };
+		A049CE232BCAB9410068BE9F /* FilterService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterService.swift; sourceTree = "<group>"; };
+		A057C71A2BCED02A00B6FA11 /* FilterServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterServiceTests.swift; sourceTree = "<group>"; };
+		A059381F2BCA96910042802D /* FilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterView.swift; sourceTree = "<group>"; };
+		A05938212BCA97E10042802D /* KeywordFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordFilter.swift; sourceTree = "<group>"; };
+		A05938252BCA9C210042802D /* UserFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFilter.swift; sourceTree = "<group>"; };
 		A064ABA928D3ADA500572ADD /* Hax.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Hax.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A064ABAC28D3ADA500572ADD /* HaxApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HaxApp.swift; sourceTree = "<group>"; };
 		A064ABB028D3ADA600572ADD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -195,6 +210,7 @@
 		A06788A329538C4C00AA7BE0 /* HackerNewsServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HackerNewsServiceMock.swift; sourceTree = "<group>"; };
 		A068D6B02BC57D740061E192 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		A07FF27A2BB7306D0067B652 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A080E6B02BD95EC7008DD06A /* HaxWidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = HaxWidgetExtension.entitlements; sourceTree = "<group>"; };
 		A086E4672BA7755D0075B0AD /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		A092AD642954B8AC00B76D68 /* CommentRowViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentRowViewModelTests.swift; sourceTree = "<group>"; };
 		A092AD662954BE9400B76D68 /* ItemRowViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemRowViewModelTests.swift; sourceTree = "<group>"; };
@@ -290,6 +306,7 @@
 			children = (
 				A01F70F229520CE100395B2A /* AppVersionServiceTests.swift */,
 				A01F70E62952051D00395B2A /* DefaultFeedServiceTests.swift */,
+				A057C71A2BCED02A00B6FA11 /* FilterServiceTests.swift */,
 				A0D56A8D2BAB35220095BDD6 /* RegexServiceTests.swift */,
 			);
 			path = Services;
@@ -353,6 +370,7 @@
 		A03FDF7A2AB74EA600127AB6 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				A080E6B02BD95EC7008DD06A /* HaxWidgetExtension.entitlements */,
 				A03FDF712AB74E5B00127AB6 /* Info.plist */,
 				A03FDF6F2AB74E5B00127AB6 /* Assets.xcassets */,
 			);
@@ -368,6 +386,15 @@
 				A0ACA6D22AD556D2007C2B8C /* SelectFeedIntent.swift */,
 			);
 			path = HaxWidget;
+			sourceTree = "<group>";
+		};
+		A05938272BCA9C540042802D /* Filters */ = {
+			isa = PBXGroup;
+			children = (
+				A05938212BCA97E10042802D /* KeywordFilter.swift */,
+				A05938252BCA9C210042802D /* UserFilter.swift */,
+			);
+			path = Filters;
 			sourceTree = "<group>";
 		};
 		A064ABA028D3ADA500572ADD = {
@@ -493,6 +520,7 @@
 			children = (
 				A067889229530F9A00AA7BE0 /* ArrayExtensionTests.swift */,
 				A0678890295309A400AA7BE0 /* DateExtensionTests.swift */,
+				A0266F652BDAA715007ED222 /* StringExtensionTests.swift */,
 				A064ABDC28D3C0E400572ADD /* URLExtensionTests.swift */,
 			);
 			path = Extensions;
@@ -547,6 +575,7 @@
 				A0F4DB0728D4EA3F006CD8E7 /* Feed.swift */,
 				A0F4DB0628D4EA3F006CD8E7 /* IdentifiableURL.swift */,
 				A0F4DB0528D4EA3F006CD8E7 /* Item.swift */,
+				A05938272BCA9C540042802D /* Filters */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -571,6 +600,7 @@
 				A0F4DB1628D4EA3F006CD8E7 /* ActivityIndicatorView.swift */,
 				A0F4DB1328D4EA3F006CD8E7 /* CommentRowView.swift */,
 				A0F4DB1728D4EA3F006CD8E7 /* FeedView.swift */,
+				A059381F2BCA96910042802D /* FilterView.swift */,
 				A0F4DB1428D4EA3F006CD8E7 /* ItemRowView.swift */,
 				A0F4DB1128D4EA3F006CD8E7 /* ItemView.swift */,
 				A0F92DB82B934EA100FE61B8 /* MainView.swift */,
@@ -587,6 +617,7 @@
 			children = (
 				A01F70F029520AAF00395B2A /* AppVersionService.swift */,
 				A01F70E3295204DD00395B2A /* DefaultFeedService.swift */,
+				A049CE232BCAB9410068BE9F /* FilterService.swift */,
 				A0F4DB1A28D4EA3F006CD8E7 /* HackerNewsService.swift */,
 				A0D56A8B2BAB32F00095BDD6 /* RegexService.swift */,
 			);
@@ -835,6 +866,7 @@
 				A02529322BC31CC7009FAAB2 /* Constant.swift in Sources */,
 				A096CE0C2AB9E741002B70BE /* Item.swift in Sources */,
 				A096CE112AB9E8C6002B70BE /* Feed.swift in Sources */,
+				A0DF5DA22BD2E36900BD93CD /* UserFilter.swift in Sources */,
 				A096CE0F2AB9E775002B70BE /* DateExtension.swift in Sources */,
 				A096CE0E2AB9E772002B70BE /* URLExtension.swift in Sources */,
 				A096CE102AB9E781002B70BE /* ArrayExtension.swift in Sources */,
@@ -844,8 +876,10 @@
 				A0ACA6D32AD556D2007C2B8C /* SelectFeedIntent.swift in Sources */,
 				A07D1C0C2AD323C30081FBE8 /* AnyPublisherExtension.swift in Sources */,
 				A03FDF6E2AB74E5A00127AB6 /* HaxWidget.swift in Sources */,
+				A0DF5DA12BD2E36500BD93CD /* KeywordFilter.swift in Sources */,
 				A03FDF7F2AB7535100127AB6 /* HaxWidgetEntry.swift in Sources */,
 				A0C19F2E2AFC22BE00D294C3 /* WidgetFamilyExtension.swift in Sources */,
+				A0DF5DA02BD2E35A00BD93CD /* FilterService.swift in Sources */,
 				A03FDF7D2AB7516F00127AB6 /* HaxWidgetProvider.swift in Sources */,
 				A04500932BBB239E006227CE /* FeedExtension.swift in Sources */,
 			);
@@ -855,6 +889,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A05938262BCA9C210042802D /* UserFilter.swift in Sources */,
 				A0F4DB2428D4EA3F006CD8E7 /* FeedViewModel.swift in Sources */,
 				A02529312BC31C8B009FAAB2 /* Constant.swift in Sources */,
 				A0F4DB2C28D4EA3F006CD8E7 /* FeedView.swift in Sources */,
@@ -867,6 +902,7 @@
 				A0F4DB1F28D4EA3F006CD8E7 /* ItemViewModel.swift in Sources */,
 				A0DEE10D2AB6F7F5000918CB /* AnyPublisherExtension.swift in Sources */,
 				A0F4DB0128D4EA25006CD8E7 /* DateExtension.swift in Sources */,
+				A049CE242BCAB9410068BE9F /* FilterService.swift in Sources */,
 				A064ABAD28D3ADA500572ADD /* HaxApp.swift in Sources */,
 				A025292F2BC31A7B009FAAB2 /* ShareView.swift in Sources */,
 				A0F4DAFF28D4EA25006CD8E7 /* StringExtension.swift in Sources */,
@@ -876,6 +912,7 @@
 				A064ABD928D3C0B600572ADD /* URLExtension.swift in Sources */,
 				A01F70E4295204DD00395B2A /* DefaultFeedService.swift in Sources */,
 				A064ABDB28D3C0CC00572ADD /* ArrayExtension.swift in Sources */,
+				A05938222BCA97E10042802D /* KeywordFilter.swift in Sources */,
 				A0F4DB2928D4EA3F006CD8E7 /* ItemRowView.swift in Sources */,
 				A0F4DB0028D4EA25006CD8E7 /* UserDefaultsExtension.swift in Sources */,
 				A0F4DAFE28D4EA25006CD8E7 /* ViewExtension.swift in Sources */,
@@ -883,6 +920,7 @@
 				A0F4DB2D28D4EA3F006CD8E7 /* MenuView.swift in Sources */,
 				A0F4DB1D28D4EA3F006CD8E7 /* IdentifiableURL.swift in Sources */,
 				A0F4DB2228D4EA3F006CD8E7 /* MenuViewModel.swift in Sources */,
+				A05938202BCA96910042802D /* FilterView.swift in Sources */,
 				A0F4DB2028D4EA3F006CD8E7 /* ItemRowViewModel.swift in Sources */,
 				A0F92DB92B934EA100FE61B8 /* MainView.swift in Sources */,
 				A0D56A8C2BAB32F00095BDD6 /* RegexService.swift in Sources */,
@@ -901,8 +939,10 @@
 				A067889329530F9A00AA7BE0 /* ArrayExtensionTests.swift in Sources */,
 				A0A2881829521A0500CF1484 /* FeedViewModelTests.swift in Sources */,
 				A0ACA52E2B935D9E00CFD2A8 /* MainViewModelTests.swift in Sources */,
+				A057C71B2BCED02A00B6FA11 /* FilterServiceTests.swift in Sources */,
 				A01F70EA2952054200395B2A /* UserDefaultsMock.swift in Sources */,
 				A0D56A8E2BAB35220095BDD6 /* RegexServiceTests.swift in Sources */,
+				A0266F662BDAA715007ED222 /* StringExtensionTests.swift in Sources */,
 				A0678891295309A400AA7BE0 /* DateExtensionTests.swift in Sources */,
 				A092AD652954B8AC00B76D68 /* CommentRowViewModelTests.swift in Sources */,
 				A064ABDD28D3C0E400572ADD /* URLExtensionTests.swift in Sources */,
@@ -970,6 +1010,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = HaxWidget/Resources/HaxWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = B2NJF5A6ZC;
@@ -1003,6 +1044,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = HaxWidget/Resources/HaxWidgetExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = B2NJF5A6ZC;

--- a/Hax/Extensions/StringExtension.swift
+++ b/Hax/Extensions/StringExtension.swift
@@ -6,8 +6,21 @@
 //
 
 import Foundation
+import RegexBuilder
 
 extension String {
+
+    // MARK: Methods
+
+    func contains(word: String) -> Bool {
+        contains(
+            Regex {
+                Anchor.wordBoundary
+                word
+                Anchor.wordBoundary
+            }
+        )
+    }
 
     // swiftlint:disable function_body_length
     /// Returns the result of converting any HTML content in the string into Markdown.

--- a/Hax/HaxApp.swift
+++ b/Hax/HaxApp.swift
@@ -26,5 +26,12 @@ struct HaxApp: App {
                     }
                 }
         }
+        .modelContainer(
+            for: [KeywordFilter.self, UserFilter.self]
+        ) { result in
+            HackerNewsService.shared.filterService = (try? result.get().mainContext).map {
+                FilterService(modelContext: $0)
+            }
+        }
     }
 }

--- a/Hax/Models/Filters/KeywordFilter.swift
+++ b/Hax/Models/Filters/KeywordFilter.swift
@@ -1,0 +1,23 @@
+//
+//  KeywordFilter.swift
+//  Hax
+//
+//  Created by Luis Fariña on 13/4/24.
+//
+
+import SwiftData
+
+@Model
+final class KeywordFilter {
+
+    // MARK: Properties
+
+    @Attribute(.unique)
+    let keyword: String
+
+    // MARK: Initialization
+
+    init(keyword: String) {
+        self.keyword = keyword
+    }
+}

--- a/Hax/Models/Filters/UserFilter.swift
+++ b/Hax/Models/Filters/UserFilter.swift
@@ -1,0 +1,23 @@
+//
+//  UserFilter.swift
+//  Hax
+//
+//  Created by Luis Fariña on 13/4/24.
+//
+
+import SwiftData
+
+@Model
+final class UserFilter {
+
+    // MARK: Properties
+
+    @Attribute(.unique)
+    let user: String
+
+    // MARK: Initialization
+
+    init(user: String) {
+        self.user = user
+    }
+}

--- a/Hax/Resources/Localizable.xcstrings
+++ b/Hax/Resources/Localizable.xcstrings
@@ -111,6 +111,36 @@
         }
       }
     },
+    "Add New Filter" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Añadir filtro nuevo"
+          }
+        }
+      }
+    },
+    "Add New Keyword Filter" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Añadir filtro de palabra clave nuevo"
+          }
+        }
+      }
+    },
+    "Add New User Filter" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Añadir filtro de usuario nuevo"
+          }
+        }
+      }
+    },
     "Ask" : {
       "localizations" : {
         "es" : {
@@ -181,6 +211,16 @@
         }
       }
     },
+    "Filters" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filtros"
+          }
+        }
+      }
+    },
     "Hacker News Link" : {
       "localizations" : {
         "es" : {
@@ -201,6 +241,26 @@
         }
       }
     },
+    "Input the keyword that, if present in stories or comments, these should be filtered out." : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Introduce la palabra clave que, si está presente en historias o comentarios, estos deben filtrarse."
+          }
+        }
+      }
+    },
+    "Input the user whose stories and comments you want to filter out." : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Introduce el usuario cuyas historias y comentarios deseas filtrar."
+          }
+        }
+      }
+    },
     "Invalid Hacker News Link" : {
       "localizations" : {
         "es" : {
@@ -217,6 +277,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Jobs"
+          }
+        }
+      }
+    },
+    "Keywords" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Palabras clave"
           }
         }
       }
@@ -387,6 +457,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Error desconocido"
+          }
+        }
+      }
+    },
+    "Users" : {
+      "localizations" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usuarios"
           }
         }
       }

--- a/Hax/Services/FilterService.swift
+++ b/Hax/Services/FilterService.swift
@@ -1,0 +1,92 @@
+//
+//  FilterService.swift
+//  Hax
+//
+//  Created by Luis Fariña on 13/4/24.
+//
+
+import SwiftData
+
+protocol FilterServiceProtocol {
+
+    // MARK: Methods
+
+    func filtered(items: [Item]) -> [Item]
+}
+
+struct FilterService: FilterServiceProtocol {
+
+    // MARK: Properties
+
+    private let modelContext: ModelContext
+
+    // MARK: Initialization
+
+    init(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    // MARK: Methods
+
+    func filtered(items: [Item]) -> [Item] {
+        let keywordFilters = fetch() as [KeywordFilter]
+        let userFilters = fetch() as [UserFilter]
+
+        return items.filter { item in
+            !item.deleted &&
+            !item.dead &&
+            noFilteredKeywordIsPresent(
+                item: item,
+                keywordFilters: keywordFilters
+            ) &&
+            userIsNotFiltered(
+                item: item,
+                userFilters: userFilters
+            )
+        }
+    }
+}
+
+// MARK: - Private extension
+
+private extension FilterService {
+
+    // MARK: Methods
+
+    func noFilteredKeywordIsPresent(
+        item: Item,
+        keywordFilters: [KeywordFilter]
+    ) -> Bool {
+        keywordFilters.allSatisfy { keywordFilter in
+            [
+                item.body,
+                item.url?.absoluteString,
+                item.title
+            ]
+                .allSatisfy { string in
+                    guard let string else {
+                        return true
+                    }
+
+                    return !string.localizedLowercase.contains(word: keywordFilter.keyword)
+                }
+        }
+    }
+
+    func userIsNotFiltered(
+        item: Item,
+        userFilters: [UserFilter]
+    ) -> Bool {
+        guard let author = item.author else {
+            return true
+        }
+
+        return !userFilters.contains { userFilter in
+            userFilter.user == author
+        }
+    }
+
+    func fetch<T: PersistentModel>() -> [T] {
+        (try? modelContext.fetch(FetchDescriptor<T>())) ?? []
+    }
+}

--- a/Hax/Services/HackerNewsService.swift
+++ b/Hax/Services/HackerNewsService.swift
@@ -90,6 +90,9 @@ final class HackerNewsService: HackerNewsServiceProtocol {
         return decoder
     }()
 
+    /// The service to use to filter items and comments.
+    var filterService: FilterServiceProtocol?
+
     // MARK: Methods
 
     func comments(
@@ -273,7 +276,7 @@ private extension HackerNewsService {
                 .replaceError(with: nil)
         })
             .collect()
-            .map { items in
+            .map { [self] items in
                 let items = items.compactMap { $0 }
 
                 // Sort the items following the order established
@@ -286,7 +289,7 @@ private extension HackerNewsService {
                     dictionary[identifier]
                 }
 
-                return sortedItems.filter { !$0.deleted && !$0.dead }
+                return filterService?.filtered(items: sortedItems) ?? sortedItems
             }
             .eraseToAnyPublisher()
     }

--- a/Hax/Views/FilterView.swift
+++ b/Hax/Views/FilterView.swift
@@ -1,0 +1,147 @@
+//
+//  FilterView.swift
+//  Hax
+//
+//  Created by Luis Fariña on 13/4/24.
+//
+
+import SwiftData
+import SwiftUI
+
+struct FilterView: View {
+
+    // MARK: Properties
+
+    @Environment(\.modelContext) var modelContext
+    @Query var keywordFilters: [KeywordFilter]
+    @Query var userFilters: [UserFilter]
+    @State var addNewKeywordFilterAlertIsPresented = false
+    @State var addNewKeywordFilterAlertText = ""
+    @State var addNewUserFilterAlertIsPresented = false
+    @State var addNewUserFilterAlertText = ""
+
+    // MARK: Body
+
+    var body: some View {
+        Form {
+            section(
+                "Keywords",
+                models: keywordFilters,
+                addNewFilterAlertIsPresented: $addNewKeywordFilterAlertIsPresented,
+                text: \.keyword
+            )
+            section(
+                "Users",
+                models: userFilters,
+                addNewFilterAlertIsPresented: $addNewUserFilterAlertIsPresented,
+                text: \.user
+            )
+        }
+        .alert(
+            "Add New Keyword Filter",
+            message: "Input the keyword that, if present in stories or comments, these should be filtered out.",
+            isPresented: $addNewKeywordFilterAlertIsPresented,
+            text: $addNewKeywordFilterAlertText
+        ) { keyword in
+            modelContext.insert(KeywordFilter(keyword: keyword.localizedLowercase))
+        }
+        .alert(
+            "Add New User Filter",
+            message: "Input the user whose stories and comments you want to filter out.",
+            isPresented: $addNewUserFilterAlertIsPresented,
+            text: $addNewUserFilterAlertText
+        ) { user in
+            modelContext.insert(UserFilter(user: user))
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationTitle("Filters")
+    }
+}
+
+// MARK: - Private extensions
+
+@MainActor
+private extension FilterView {
+
+    // MARK: Methods
+
+    func section<T: PersistentModel>(
+        _ titleKey: LocalizedStringKey,
+        models: [T],
+        addNewFilterAlertIsPresented: Binding<Bool>,
+        text: @escaping (T) -> String
+    ) -> some View {
+        Section(titleKey) {
+            List {
+                ForEach(models) { model in
+                    Text(text(model))
+                }
+                .onDelete { indexSet in
+                    delete(models, at: indexSet)
+                }
+                Button {
+                    addNewFilterAlertIsPresented.wrappedValue = true
+                } label: {
+                    Label("Add New Filter", systemImage: "plus")
+                }
+            }
+        }
+    }
+
+    func delete<T: PersistentModel>(
+        _ models: [T],
+        at indexSet: IndexSet
+    ) {
+        for index in indexSet {
+            modelContext.delete(models[index])
+        }
+    }
+}
+
+private extension View {
+
+    // MARK: Methods
+
+    func alert(
+        _ titleKey: LocalizedStringKey,
+        message: LocalizedStringKey,
+        isPresented: Binding<Bool>,
+        text: Binding<String>,
+        onOKButtonTrigger: @escaping (String) -> Void
+    ) -> some View {
+        alert(titleKey, isPresented: isPresented) {
+            TextField(String(""), text: text)
+                .disableAutocorrection(true)
+                .textInputAutocapitalization(.never)
+            Button("Cancel") {
+                text.wrappedValue = ""
+            }
+            Button("OK") {
+                if !text.wrappedValue.isEmpty {
+                    onOKButtonTrigger(text.wrappedValue)
+                }
+                text.wrappedValue = ""
+            }
+            .keyboardShortcut(.defaultAction)
+        } message: {
+            Text(message)
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview {
+    NavigationStack {
+        FilterView()
+    }
+    .modelContainer(
+        for: [KeywordFilter.self, UserFilter.self],
+        inMemory: true
+    ) { result in
+        if let modelContext = try? result.get().mainContext {
+            modelContext.insert(KeywordFilter(keyword: "keyword"))
+            modelContext.insert(UserFilter(user: "user"))
+        }
+    }
+}

--- a/Hax/Views/SettingsView.swift
+++ b/Hax/Views/SettingsView.swift
@@ -28,6 +28,11 @@ struct SettingsView<Model: SettingsViewModelProtocol>: View {
                 } label: {
                     Text("Default Feed")
                 }
+                NavigationLink {
+                    FilterView()
+                } label: {
+                    Label("Filters", systemImage: "eye.slash")
+                }
             }
             Section("About") {
                 Button("Privacy Policy") {

--- a/HaxTests/Tests/Extensions/StringExtensionTests.swift
+++ b/HaxTests/Tests/Extensions/StringExtensionTests.swift
@@ -1,0 +1,36 @@
+//
+//  StringExtensionTests.swift
+//  HaxTests
+//
+//  Created by Luis Fariña on 25/4/24.
+//
+
+import XCTest
+@testable import Hax
+
+final class StringExtensionTests: XCTestCase {
+
+    // MARK: Tests
+
+    func testContainsWord_givenStringDoesNotContainWord() {
+        // Given
+        let sut = "Thisstringdoesnotcontaintheword."
+
+        // When
+        let containsWord = sut.contains(word: "word")
+
+        // Then
+        XCTAssertFalse(containsWord)
+    }
+
+    func testContainsWord_givenStringContainsWord() {
+        // Given
+        let sut = "This string contains the word."
+
+        // When
+        let containsWord = sut.contains(word: "word")
+
+        // Then
+        XCTAssert(containsWord)
+    }
+}

--- a/HaxTests/Tests/Services/FilterServiceTests.swift
+++ b/HaxTests/Tests/Services/FilterServiceTests.swift
@@ -1,0 +1,120 @@
+//
+//  FilterServiceTests.swift
+//  HaxTests
+//
+//  Created by Luis Fariña on 16/4/24.
+//
+
+import SwiftData
+import XCTest
+@testable import Hax
+
+@MainActor
+final class FilterServiceTests: XCTestCase {
+
+    // MARK: Properties
+
+    private var sut: FilterService!
+
+    // MARK: Set up and tear down
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        let modelConfiguration = ModelConfiguration(isStoredInMemoryOnly: true)
+        let modelContainer = try ModelContainer(
+            for: KeywordFilter.self,
+            UserFilter.self,
+            configurations: modelConfiguration
+        )
+        let modelContext = modelContainer.mainContext
+        modelContext.insert(KeywordFilter(keyword: "keyword"))
+        modelContext.insert(UserFilter(user: "author"))
+        sut = FilterService(modelContext: modelContext)
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+
+        try super.tearDownWithError()
+    }
+
+    // MARK: Tests
+
+    func testFilteredItems_givenItemWhichIsDeleted() {
+        // Given
+        let item = Item(deleted: true)
+
+        // When
+        let filteredItems = sut.filtered(items: [item])
+
+        // Then
+        XCTAssert(filteredItems.isEmpty)
+    }
+
+    func testFilteredItems_givenItemWhichIsDead() {
+        // Given
+        let item = Item(dead: true)
+
+        // When
+        let filteredItems = sut.filtered(items: [item])
+
+        // Then
+        XCTAssert(filteredItems.isEmpty)
+    }
+
+    func testFilteredItems_givenItemWhoseBodyHasFilteredKeyword() {
+        // Given
+        let item = Item(body: "keyword")
+
+        // When
+        let filteredItems = sut.filtered(items: [item])
+
+        // Then
+        XCTAssert(filteredItems.isEmpty)
+    }
+
+    func testFilteredItems_givenItemWhoseURLHasFilteredKeyword() {
+        // Given
+        let item = Item(url: URL(string: "https://luisfl.me/keyword"))
+
+        // When
+        let filteredItems = sut.filtered(items: [item])
+
+        // Then
+        XCTAssert(filteredItems.isEmpty)
+    }
+
+    func testFilteredItems_givenItemWhoseTitleHasFilteredKeyword() {
+        // Given
+        let item = Item(title: "keyword")
+
+        // When
+        let filteredItems = sut.filtered(items: [item])
+
+        // Then
+        XCTAssert(filteredItems.isEmpty)
+    }
+
+    func testFilteredItems_givenItemWhoseAuthorIsFiltered() {
+        // Given
+        let item = Item(author: "author")
+
+        // When
+        let filteredItems = sut.filtered(items: [item])
+
+        // Then
+        XCTAssert(filteredItems.isEmpty)
+    }
+
+    func testFilteredItems_givenItemWithoutFilteredKeywordsAndWhoseAuthorIsNotFiltered() {
+        // Given
+        let item = Item()
+
+        // When
+        let filteredItems = sut.filtered(items: [item])
+
+        // Then
+        XCTAssertEqual(filteredItems, [item])
+    }
+}

--- a/HaxWidget/Resources/HaxWidgetExtension.entitlements
+++ b/HaxWidget/Resources/HaxWidgetExtension.entitlements
@@ -2,13 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.luisfl.Hax</string>
 	</array>
-	<key>com.apple.security.files.user-selected.read-only</key>
-	<true/>
 </dict>
 </plist>

--- a/HaxWidget/Widgets/HaxWidget/HaxWidget.swift
+++ b/HaxWidget/Widgets/HaxWidget/HaxWidget.swift
@@ -76,6 +76,7 @@ struct HaxWidget: Widget {
 
     // MARK: Body
 
+    @MainActor
     var body: some WidgetConfiguration {
         AppIntentConfiguration(
             kind: String(describing: Self.self),

--- a/HaxWidget/Widgets/HaxWidget/HaxWidgetProvider.swift
+++ b/HaxWidget/Widgets/HaxWidget/HaxWidgetProvider.swift
@@ -5,9 +5,25 @@
 //  Created by Luis Fariña on 17/9/23.
 //
 
+import SwiftData
 import WidgetKit
 
 struct HaxWidgetProvider: AppIntentTimelineProvider {
+
+    // MARK: Initialization
+
+    @MainActor
+    init() {
+        let modelConfiguration = ModelConfiguration()
+        let modelContainer = try? ModelContainer(
+            for: KeywordFilter.self,
+            UserFilter.self,
+            configurations: modelConfiguration
+        )
+        HackerNewsService.shared.filterService = modelContainer.map {
+            FilterService(modelContext: $0.mainContext)
+        }
+    }
 
     // MARK: Methods
 


### PR DESCRIPTION
* Create two `SwiftData` models, `KeywordFilter` and `UserFilter`
* Create a view for adding and deleting filters, `FilterView`, which takes advantage of the new `@Query` macro
  * No view model has been created for the view because such macro can't be used outside `View` instances
* Create `FilterService` with a method, `filtered(items:)`, which filters an array of `Item` instances depending on the persisted filters
* Modify `HackerNewsService` to use `FilterService` to filter the fetched items
* Modify `HaxApp` to set the `ModelContainer` instance of the entire app and inject a `FilterService` instance into the `HackerNewsService` singleton (will get rid of this singleton soon)
* Extend `String` with a `contains(word:)` method that returns whether a word, not a substring, is contained within the string
* Assign both the main and the widget targets to an app group so that the filters are shared between them
* Modify `HaxWidgetProvider` to initialize the `ModelContainer` instance similarly to how it's done in `HaxApp`